### PR TITLE
add support for cohere, replicate, azure

### DIFF
--- a/easyinstruct/prompts/base_prompt.py
+++ b/easyinstruct/prompts/base_prompt.py
@@ -1,7 +1,8 @@
 import openai
 import anthropic
 from typing import Optional, Union, List
-
+import litellm
+from litellm import completion
 from easyinstruct.utils.api import API_NAME_DICT
 from easyinstruct.utils.api import get_openai_key, get_anthropic_key
 from easyinstruct.engines import llama_engine
@@ -53,7 +54,7 @@ class BasePrompt:
             else:
                 raise ValueError("system_message should be either a string or a list of strings.")
 
-            response = openai.ChatCompletion.create(
+            response = completion(
                 model = engine,
                 messages = messages,
                 temperature = temperature,


### PR DESCRIPTION
Hi @zxlzr @OE-Heart,

Noticed you're calling multiple providers. I'm working on litellm (simple library to standardize LLM API Calls - https://github.com/BerriAI/litellm) and was wondering if we could be helpful.

I added support for Cohere, Azure and Llama2 (via Replicate) by replacing the openai `ChatCompletion.create` endpoint with `completion`. The code is pretty similar to the OpenAI class - as litellm follows the same pattern as the openai-python sdk.

Would love to know if this helps.

Happy to add additional tests / update documentation, if the initial PR looks good to you.